### PR TITLE
mah.se -> mau.se

### DIFF
--- a/lib/domains/se/mah.txt
+++ b/lib/domains/se/mah.txt
@@ -1,1 +1,0 @@
-Malmö University College

--- a/lib/domains/se/mau.txt
+++ b/lib/domains/se/mau.txt
@@ -1,0 +1,1 @@
+Malmö University


### PR DESCRIPTION
The name of Malmö University in Swedish changed from Malmö högskola (Mah) to Malmö universitet (Mau), and their domain was changed to reflect this.

Note that https://mah.se/ redirects to https://mau.se/