### PR TITLE
hcmuns.txt to hcmus.txt

### DIFF
--- a/lib/domains/vn/edu/hcmuns.txt
+++ b/lib/domains/vn/edu/hcmuns.txt
@@ -1,1 +1,0 @@
-Ho Chi Minh City University of Natural Sciences

--- a/lib/domains/vn/edu/hcmus.txt
+++ b/lib/domains/vn/edu/hcmus.txt
@@ -1,0 +1,1 @@
+Ho Chi Minh City University of Science


### PR DESCRIPTION
Ho Chi Minh City University of Natural Science has been rename to Ho Chi Minh City University of Science

Their website: [https://hcmus.edu.vn](https://en.hcmus.edu.vn)